### PR TITLE
Fix: Only get commits between the "last" and "new" commits

### DIFF
--- a/cmd/release-notes/fetch.go
+++ b/cmd/release-notes/fetch.go
@@ -7,10 +7,10 @@ import (
 )
 
 const query = `
-query ($after: String, $timestamp: GitTimestamp!) {
+query ($after: String, $timestamp: GitTimestamp!, $newRelease: String) {
   repository(owner: "osquery", name: "osquery") {
     nameWithOwner
-    object(expression: "master") {
+    object(expression: $newRelease) {
       ... on Commit {
         oid
         history(first: 100, after: $after, since: $timestamp) {
@@ -89,7 +89,7 @@ type responseType struct {
 	}
 }
 
-func fetchCommits(ctx context.Context, graphqlClient *graphql.Client, token string, timestamp string) ([]responseType, error) {
+func fetchCommits(ctx context.Context, graphqlClient *graphql.Client, token string, timestamp string, newRelease string) ([]responseType, error) {
 	responses := []responseType{}
 
 	cursor := ""
@@ -103,6 +103,9 @@ func fetchCommits(ctx context.Context, graphqlClient *graphql.Client, token stri
 		// Empirically, we can always have timestamp. The
 		// after cursor still has the desired effect.
 		req.Var("timestamp", timestamp)
+
+		// We need a commit range between timestamp and the commit newRelease
+		req.Var("newRelease", newRelease)
 
 		// Set pagination
 		if cursor != "" {

--- a/cmd/release-notes/main.go
+++ b/cmd/release-notes/main.go
@@ -60,7 +60,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	commits, err := getGitCommits(ctx, graphqlClient, *flGithubToken, timestamp)
+	commits, err := getGitCommits(ctx, graphqlClient, *flGithubToken, timestamp, *flNewRelease)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -228,8 +228,8 @@ func (c *Commit) labelsInclude(labels ...string) bool {
 	return true
 }
 
-func getGitCommits(ctx context.Context, graphqlClient *graphql.Client, token string, timestamp string) ([]*Commit, error) {
-	responses, err := fetchCommits(ctx, graphqlClient, token, timestamp)
+func getGitCommits(ctx context.Context, graphqlClient *graphql.Client, token string, timestamp string, newRelease string) ([]*Commit, error) {
+	responses, err := fetchCommits(ctx, graphqlClient, token, timestamp, newRelease)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently the range taken is from the "last" commit timestamp and "master", but we don't want commits that are after the release we are creating the changelog for.
Using the "new" tag instead of the hardcoded string "master" achieves this.
